### PR TITLE
Cacher les messages au lieu de les supprimer

### DIFF
--- a/deboucled.user.js
+++ b/deboucled.user.js
@@ -1077,9 +1077,9 @@ function updateMessagesHeader() {
 }
 
 function removeMessage(element) {
-    if (element.previousElementSibling) element.previousElementSibling.remove();
-    else if (element.nextElementSibling) element.nextElementSibling.remove();
-    element.remove();
+    if (element.previousElementSibling) element.previousElementSibling.hidden = true;
+    else if (element.nextElementSibling) element.nextElementSibling.hidden = true;
+    element.hidden = true;
 }
 
 function upgradeJvcBlacklistButton(messageElement, author, optionShowJvcBlacklistButton) {


### PR DESCRIPTION
Améliore la compatibilité avec JVC Ghost, qui restaure les messages supprimés. On cache les messages au lieu de les supprimer, sinon, JVC Ghost "restaure" les messages des auteurs bouclés.