### PR TITLE
Affiche proprement les mosaïques 🖼️

### DIFF
--- a/deboucled.css
+++ b/deboucled.css
@@ -2435,3 +2435,8 @@ select.deboucled-dropdown::-ms-expand {
     font: 11px/14px sans-serif;
   }
 }
+
+.text-enrichi-forum .img-shack {
+  margin-right: -4px;
+  margin-bottom: -7px;
+}


### PR DESCRIPTION
Petite modif CSS 

Avant : 

 
![image](https://github.com/user-attachments/assets/34c20e15-02ee-41f8-bb74-769cef931214)



Après : 
![image](https://github.com/user-attachments/assets/7f9358d7-4b02-4810-a589-b41e2f56c6bb)



