### PR TITLE
Show user's own deleted message in profile with jvarchive api

### DIFF
--- a/jvarchiveapi.js
+++ b/jvarchiveapi.js
@@ -6,16 +6,21 @@
 const jvarchiveApiUrl = `${jvarchiveUrl}/api`;
 const jvarchiveApiTopicsUrl = `${jvarchiveApiUrl}/topics`;
 const jvarchiveApiAuteursUrl = `${jvarchiveApiUrl}/auteurs`;
+const jvarchiveMessagesUrl = `${jvarchiveApiUrl}/messages`;
 
 const jvarchiveApiGetHotTopicsRoute = (itemsPerPage, timeInterval) => `${jvarchiveApiTopicsUrl}?page=1&itemsPerPage=${itemsPerPage}&orderBy=nb_messages&timeInterval=${timeInterval}&topicState=created`;
 const jvarchiveApiGetAuthorRoute = (author) => `${jvarchiveApiAuteursUrl}/${author}`;
 const jvarchiveApiGetAuthorLastMessagesRoute = (author) => `${jvarchiveApiAuteursUrl}/${author}/last5messages`;
 const jvarchiveApiGetAuthorLastTopicsRoute = (author, itemsPerPage) => `${jvarchiveApiTopicsUrl}/search?page=1&itemsPerPage=${itemsPerPage}&search=${author}&searchType=auteur_topic_exact`;
+const jvarchiveApiGetMessageRoute = (id) => `${jvarchiveMessagesUrl}/${id}`;
+
 
 const getJvArchiveHotTopics = async (itemsPerPage = 20, timeInterval = 'day') => fetchJson(jvarchiveApiGetHotTopicsRoute(itemsPerPage, timeInterval), 3000);
 const getJvArchiveAuthor = async (author) => fetchJson(jvarchiveApiGetAuthorRoute(author), 3000);
 const getJvArchiveAuthorLastMessages = async (author) => fetchJson(jvarchiveApiGetAuthorLastMessagesRoute(author), 3000);
 const getJvArchiveAuthorLastTopics = async (author, itemsPerPage = 5) => fetchJson(jvarchiveApiGetAuthorLastTopicsRoute(author, itemsPerPage), 3000);
+const getJvArchiveMessage = async (id) => fetchJson(jvarchiveApiGetMessageRoute(id), 3000);
+
 
 const jvArchiveTop1Url = `${jvarchiveUrl}/_nuxt/img/1.24cfc48.svg`;
 const jvArchiveTop2Url = `${jvarchiveUrl}/_nuxt/img/2.84b5d8d.svg`;

--- a/main.js
+++ b/main.js
@@ -806,6 +806,10 @@ async function handleProfile(profileTab) {
         await buildProfileStats(author);
         await buildProfileHistory(author);
     }
+
+    if (profileTab.match(/^\?mode=historique_forum/i)) {
+        await showDeletedMessages();
+    }
 }
 
 async function handlePrivateMessageNotifs() {

--- a/profile.js
+++ b/profile.js
@@ -274,3 +274,24 @@ async function buildProfileHistory(author) {
     }
 }
 
+async function showDeletedMessages() {
+    const deletedMessages = document.querySelectorAll('.msg-supprime-gta, .msg-supprime');
+
+    deletedMessages.forEach(async (message) => {
+        const messageId = message.getAttribute('data-id');
+        if (!messageId) return;
+
+        const jvaMessage = await getJvArchiveMessage(messageId);
+        if (!jvaMessage?.texte) return;
+
+        const texteElement = message.querySelector('div.text-enrichi-forum');
+        if (!texteElement) return;
+
+        if(!jvaMessage.texte.includes('<p>')){
+            jvaMessage.texte = '<p>' + jvaMessage.texte + '</p>';
+        }
+        texteElement.innerHTML = jvaMessage.texte;       
+    } );
+
+ 
+}


### PR DESCRIPTION
Au lieu de "Message supprimé." ca charge les messages via jv archive dans l'historique du profil 

ça marche, mais il y a des erreur avec le fetchJson : 

![image](https://github.com/user-attachments/assets/1f6054e0-0277-43eb-ad37-559086260650)
![image](https://github.com/user-attachments/assets/f4bd1afe-4c27-45a0-8722-28c1fb37dfde)


