### PR TITLE
Fix: preview loupe mobile 🔍 

### DIFF
--- a/deboucled.css
+++ b/deboucled.css
@@ -2410,6 +2410,9 @@ select.deboucled-dropdown::-ms-expand {
   .deboucled-badge.close {
     margin: 0.4rem 0 0.8rem 0.2rem;
   }
+  .deboucled-preview-content { 
+    width: 90%;
+  }
 }
 @media (max-width: 558px) {
   .deboucled-overlay {

--- a/topics.js
+++ b/topics.js
@@ -651,8 +651,7 @@ function addPrevisualizeTopicEvent(topics) {
         if (!topicTitleElement) return;
         const topicUrl = topicTitleElement.getAttribute('href');
 
-        let anchor = document.createElement('a');
-        anchor.setAttribute('href', topicUrl);
+        let anchor = document.createElement('span');
         anchor.setAttribute('class', 'deboucled-topic-preview-col');
         anchor.innerHTML = '<svg viewBox="0 0 30 30" id="deboucled-preview-logo" class="deboucled-logo-preview"><use href="#previewlogo"/></svg>';
         let topicImg = topic.querySelector('.topic-img');


### PR DESCRIPTION
Sur mobile si la loupe est un lien clickable, ça propose d'ouvrir le lien, et on ne peut pas voir la preview, alors j'ai enlever le lien et ça fix

Changement CSS pour rendre la preview responsive sur petit écran < 611px